### PR TITLE
feature: Background Pruning

### DIFF
--- a/cache/config_test.go
+++ b/cache/config_test.go
@@ -6,9 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/karlseguin/ccache/v2"
-
 	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
+	"github.com/karlseguin/ccache/v2"
 
 	"github.com/aws/aws-sdk-go/aws/request"
 
@@ -144,7 +143,7 @@ func Test_CacheFlush(t *testing.T) {
 
 	s.Handlers.Complete.PushBack(func(r *request.Request) {
 		if IsCacheHit(r.HTTPRequest.Context()) != cacheHit {
-			t.Errorf("DescribeInstances expected cache hit %v, got %v", IsCacheHit(r.Context()), cacheHit)
+			t.Errorf("DescribeInstances expected cache hit %v, got %v", IsCacheHit(r.HTTPRequest.Context()), cacheHit)
 		}
 	})
 
@@ -185,7 +184,7 @@ func Test_BackgroundTTLPruning(t *testing.T) {
 
 	s.Handlers.Complete.PushBack(func(r *request.Request) {
 		if IsCacheHit(r.HTTPRequest.Context()) != cacheHit {
-			t.Errorf("DescribeInstances expected cache hit %v, got %v", IsCacheHit(r.Context()), cacheHit)
+			t.Errorf("DescribeInstances expected cache hit %v, got %v", IsCacheHit(r.HTTPRequest.Context()), cacheHit)
 		}
 	})
 
@@ -237,7 +236,7 @@ func Test_FlushOperationCache(t *testing.T) {
 
 	s.Handlers.Complete.PushBack(func(r *request.Request) {
 		if IsCacheHit(r.HTTPRequest.Context()) != cacheHit {
-			t.Errorf("DescribeInstances expected cache hit %v, got %v", IsCacheHit(r.Context()), cacheHit)
+			t.Errorf("DescribeInstances expected cache hit %v, got %v", IsCacheHit(r.HTTPRequest.Context()), cacheHit)
 		}
 	})
 
@@ -285,13 +284,13 @@ func Test_FlushSkipExcluded(t *testing.T) {
 	defer server.Close()
 
 	s := newSession()
-	cacheCfg := NewConfig(10*time.Second, 1*time.Hour, 5000, 500)
+	cacheCfg := NewConfig(10*time.Millisecond, 1*time.Hour, 5000, 500)
 	cacheCfg.SetExcludeFlushing("ec2", "DescribeInstances", true)
 	AddCaching(s, cacheCfg)
 
 	s.Handlers.Complete.PushBack(func(r *request.Request) {
 		if IsCacheHit(r.HTTPRequest.Context()) != cacheHit {
-			t.Errorf("DescribeInstances expected cache hit %v, got %v", IsCacheHit(r.Context()), cacheHit)
+			t.Errorf("DescribeInstances expected cache hit %v, got %v", IsCacheHit(r.HTTPRequest.Context()), cacheHit)
 		}
 	})
 

--- a/cache/config_test.go
+++ b/cache/config_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/karlseguin/ccache/v2"
+
 	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
 
 	"github.com/aws/aws-sdk-go/aws/request"
@@ -75,7 +77,7 @@ func Test_CachedError(t *testing.T) {
 	defer server.Close()
 
 	s := newSession()
-	cacheCfg := NewConfig(10 * time.Second, 5000, 500)
+	cacheCfg := NewConfig(10*time.Second, 1*time.Hour, 5000, 500)
 	AddCaching(s, cacheCfg)
 
 	svc := resourcegroupstaggingapi.New(s)
@@ -100,7 +102,7 @@ func Test_Cache(t *testing.T) {
 	defer server.Close()
 
 	s := newSession()
-	cacheCfg := NewConfig(10 * time.Second, 5000, 500)
+	cacheCfg := NewConfig(10*time.Second, 1*time.Hour, 5000, 500)
 	AddCaching(s, cacheCfg)
 
 	svc := ec2.New(s)
@@ -137,7 +139,7 @@ func Test_CacheFlush(t *testing.T) {
 	defer server.Close()
 
 	s := newSession()
-	cacheCfg := NewConfig(10 * time.Second, 5000, 500)
+	cacheCfg := NewConfig(10*time.Second, 1*time.Hour, 5000, 500)
 	AddCaching(s, cacheCfg)
 
 	s.Handlers.Complete.PushBack(func(r *request.Request) {
@@ -171,6 +173,58 @@ func Test_CacheFlush(t *testing.T) {
 	}
 }
 
+func Test_BackgroundTTLPruning(t *testing.T) {
+	server = httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.Write(describeInstancesResponse)
+	}))
+	defer server.Close()
+
+	s := newSession()
+	cacheCfg := NewConfig(400*time.Millisecond, 500*time.Millisecond, 5000, 500)
+	AddCaching(s, cacheCfg)
+
+	s.Handlers.Complete.PushBack(func(r *request.Request) {
+		if IsCacheHit(r.HTTPRequest.Context()) != cacheHit {
+			t.Errorf("DescribeInstances expected cache hit %v, got %v", IsCacheHit(r.Context()), cacheHit)
+		}
+	})
+
+	svc := ec2.New(s)
+
+	cacheHit = false
+	_, err := svc.DescribeInstances(
+		&ec2.DescribeInstancesInput{InstanceIds: []*string{aws.String("i-0ace172143b1159d6")}})
+	if err != nil {
+		t.Errorf("DescribeInstances returned an unexpected error %v", err)
+	}
+
+	cacheHit = true
+	_, err = svc.DescribeInstances(
+		&ec2.DescribeInstancesInput{InstanceIds: []*string{aws.String("i-0ace172143b1159d6")}})
+	if err != nil {
+		t.Errorf("DescribeInstances returned an unexpected error %v", err)
+	}
+
+	c, ok := cacheCfg.caches.Load("ec2.DescribeInstances")
+	if !ok {
+		t.Errorf("DescribeInstances cache not found: %v", err)
+	}
+
+	cObj := c.(*ccache.Cache)
+
+	// TTL expired - should have 1 item in cache
+	time.Sleep(401 * time.Millisecond)
+	if cObj.ItemCount() < 1 {
+		t.Error("DescribeInstances cache had 0 items")
+	}
+
+	// Background pruning done - should have 0 items in cache
+	time.Sleep(100 * time.Millisecond)
+	if cObj.ItemCount() > 0 {
+		t.Error("DescribeInstances cache had more than 0 items")
+	}
+}
+
 func Test_FlushOperationCache(t *testing.T) {
 	server = httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.Write(describeInstancesResponse)
@@ -178,7 +232,7 @@ func Test_FlushOperationCache(t *testing.T) {
 	defer server.Close()
 
 	s := newSession()
-	cacheCfg := NewConfig(10 * time.Second, 5000, 500)
+	cacheCfg := NewConfig(10*time.Second, 1*time.Hour, 5000, 500)
 	AddCaching(s, cacheCfg)
 
 	s.Handlers.Complete.PushBack(func(r *request.Request) {
@@ -231,7 +285,7 @@ func Test_FlushSkipExcluded(t *testing.T) {
 	defer server.Close()
 
 	s := newSession()
-	cacheCfg := NewConfig(10*time.Millisecond, 5000, 500)
+	cacheCfg := NewConfig(10*time.Second, 1*time.Hour, 5000, 500)
 	cacheCfg.SetExcludeFlushing("ec2", "DescribeInstances", true)
 	AddCaching(s, cacheCfg)
 
@@ -289,7 +343,7 @@ func Test_FlushSkipExcluded(t *testing.T) {
 }
 
 func Test_IsMutating(t *testing.T) {
-	cacheCfg := NewConfig(10 * time.Second, 5000, 500)
+	cacheCfg := NewConfig(10*time.Second, 1*time.Hour, 5000, 500)
 
 	if !cacheCfg.isMutating("ec2", "TerminateInstances") {
 		t.Errorf("expected TerminateInstances to be mutating")
@@ -303,7 +357,7 @@ func Test_IsMutating(t *testing.T) {
 }
 
 func Test_IsExcluded(t *testing.T) {
-	cacheCfg := NewConfig(10*time.Second, 5000, 500)
+	cacheCfg := NewConfig(10*time.Second, 1*time.Hour, 5000, 500)
 
 	if cacheCfg.isExcluded("ec2.DescribeInstanceTypes") {
 		t.Errorf("expected TerminateInstances to not be excluded")
@@ -323,7 +377,7 @@ func Test_AutoCacheFlush(t *testing.T) {
 	defer server.Close()
 
 	s := newSession()
-	cacheCfg := NewConfig(10 * time.Second, 5000, 500)
+	cacheCfg := NewConfig(10*time.Second, 1*time.Hour, 5000, 500)
 	AddCaching(s, cacheCfg)
 
 	s.Handlers.Complete.PushBack(func(r *request.Request) {

--- a/example.go
+++ b/example.go
@@ -20,7 +20,7 @@ func main() {
 	s := session.Must(session.NewSession())
 
 	// Adds caching to session
-	cacheCfg := cache.NewConfig(0 * time.Second, 5000, 500)
+	cacheCfg := cache.NewConfig(0*time.Second, 1*time.Hour, 5000, 500)
 	cache.AddCaching(s, cacheCfg)
 
 	reg := prometheus.NewRegistry()

--- a/go.mod
+++ b/go.mod
@@ -4,13 +4,10 @@ require (
 	github.com/aws/aws-sdk-go v1.35.7
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
-	github.com/karlseguin/ccache v2.0.3+incompatible
-	github.com/karlseguin/expect v1.0.1 // indirect
+	github.com/karlseguin/ccache/v2 v2.0.8
 	github.com/prometheus/client_golang v1.0.0
 	github.com/prometheus/common v0.9.1 // indirect
 	github.com/prometheus/procfs v0.0.8 // indirect
-	github.com/wsxiaoys/terminal v0.0.0-20160513160801-0940f3fc43a0 // indirect
-	gopkg.in/karlseguin/expect.v1 v1.0.1 // indirect
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -4,7 +4,6 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/aws/aws-sdk-go v1.35.7 h1:FHMhVhyc/9jljgFAcGkQDYjpC9btM0B8VfkLBfctdNE=
 github.com/aws/aws-sdk-go v1.35.7/go.mod h1:tlPOdRjfxPBpNIwqDj61rmsnA85v9jc0Ps9+muhnW+k=
-github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -20,7 +19,6 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
-github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
@@ -33,10 +31,10 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGw
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
-github.com/karlseguin/ccache v2.0.3+incompatible h1:j68C9tWOROiOLWTS/kCGg9IcJG+ACqn5+0+t8Oh83UU=
-github.com/karlseguin/ccache v2.0.3+incompatible/go.mod h1:CM9tNPzT6EdRh14+jiW8mEF9mkNZuuE51qmgGYUB93w=
-github.com/karlseguin/expect v1.0.1 h1:z4wy4npwwHSWKjGWH85WNJO42VQhovxTCZDSzhjo8hY=
-github.com/karlseguin/expect v1.0.1/go.mod h1:zNBxMY8P21owkeogJELCLeHIt+voOSduHYTFUbwRAV8=
+github.com/karlseguin/ccache/v2 v2.0.8 h1:lT38cE//uyf6KcFok0rlgXtGFBWxkI6h/qg4tbFyDnA=
+github.com/karlseguin/ccache/v2 v2.0.8/go.mod h1:2BDThcfQMf/c0jnZowt16eW405XIqZPavt+HoYEtcxQ=
+github.com/karlseguin/expect v1.0.2-0.20190806010014-778a5f0c6003 h1:vJ0Snvo+SLMY72r5J4sEfkuE7AFbixEP2qRbEcum/wA=
+github.com/karlseguin/expect v1.0.2-0.20190806010014-778a5f0c6003/go.mod h1:zNBxMY8P21owkeogJELCLeHIt+voOSduHYTFUbwRAV8=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
@@ -52,7 +50,6 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v1.0.0 h1:vrDKnkGzuGvhNAL56c7DBz29ZL+KxnoR0x7enabFceM=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
-github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910 h1:idejC8f05m9MGOsuEi1ATq9shN03HrxNkD/luQvxCv8=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.2.0 h1:uq5h0d+GuxiXLJLNABMgp2qUWDPiLvgCzz2dUR+/W/M=
@@ -68,7 +65,6 @@ github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPx
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/wsxiaoys/terminal v0.0.0-20160513160801-0940f3fc43a0 h1:3UeQBvD0TFrlVjOeLOBz+CPAI8dnbqNSVwUwRrkp7vQ=
@@ -81,7 +77,6 @@ golang.org/x/net v0.0.0-20200202094626-16171245cfb2 h1:CCH4IOTTfewWjGOlSp+zGcjut
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -93,10 +88,7 @@ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/karlseguin/expect.v1 v1.0.1 h1:9u0iUltnhFbJTHaSIH0EP+cuTU5rafIgmcsEsg2JQFw=
-gopkg.in/karlseguin/expect.v1 v1.0.1/go.mod h1:uB7QIJBcclvYbwlUDkSCsGjAOMis3fP280LyhuDEf2I=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
Ref https://github.com/keikoproj/instance-manager/issues/264

This adds improvements around pagination in order to avoid leaking additional pages and causing a memory leak.
The change simply adds background pruning based on TTL to avoid having non-existent keys from old pages stuck forever in the cache.